### PR TITLE
Minor changes to SimpleCollectable.sol

### DIFF
--- a/contracts/SimpleCollectible.sol
+++ b/contracts/SimpleCollectible.sol
@@ -5,16 +5,12 @@ import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 contract SimpleCollectible is ERC721 {
     uint256 public tokenCounter;
-    constructor () public ERC721 ("Dogie", "DOG"){
-        tokenCounter = 0;
-    }
+    constructor () public ERC721 ("Dogie", "DOG"){}
 
-    function createCollectible(string memory tokenURI) public returns (uint256) {
+    function createCollectible(string calldata tokenURI) external returns (uint256 newItemId) {
         uint256 newItemId = tokenCounter;
         _safeMint(msg.sender, newItemId);
         _setTokenURI(newItemId, tokenURI);
-        tokenCounter = tokenCounter + 1;
-        return newItemId;
+        tokenCounter++;
     }
-
 }


### PR DESCRIPTION
Changes to SimpleCollectable.sol to be easier to read and save gas by 1. getting rid of redundant tokencounter set to zero in the constructor 2. using calldata to reduce gas 3. declaring return uint in the function declaration instead of defining it in the function body.